### PR TITLE
Removed unnecessary Harmony patch

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -72,9 +72,6 @@ namespace vtolvrTelemetry
 
         public void Start()
         {
-            Harmony harmony = new Harmony("vtolvrTelemetry.logger.logger");
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
-
             udpClient = new UdpClient();
             udpClient.Connect(receiverIp, receiverPort);
 


### PR DESCRIPTION
The Mod Loader now does this for you, based off the value put in here:

https://github.com/MaGoodboi/vtolvrTelemetry-Mod/blob/a1cdb58c3b35f56a805d1de9b4b775a4c5c9b421/Main.cs#L16

So it can removed as I think it would patch the methods twice causing werd stuff to happen with a guess